### PR TITLE
Mention pkg-config in bootstrap.sh

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -5,6 +5,7 @@
 # - autoconf-archive (GNU autoconf-archive)
 # - automake (GNU automake) 1.11
 # - libtool (GNU libtool) 2.2.6
+# - pkg-config
 
 set -e
 set -x


### PR DESCRIPTION
Attempting to run bootstrap.sh without pkg-config installed prints various autoconf errors, eg:

"configure.ac:51: error: possibly undefined macro: AC_MSG_WARN"